### PR TITLE
Avoid error on wrong formating when path contains ~

### DIFF
--- a/screenshot-maim.lisp
+++ b/screenshot-maim.lisp
@@ -27,7 +27,7 @@
                             :error-output '(:string :stripped t)
                             :output nil)
         (if (eq err-code 0)
-            (message (format nil "Screenshotted to ~a" filename))
+            (message "Screenshotted to ~a" filename)
             (message err-text))))))
 
 


### PR DESCRIPTION
How it works in stumpish:
```
> screenshot-area
Error In Command 'screenshot-area': error in FORMAT: No more arguments
  Screenshotted to ~/Screenshots/screenshot-2024-02-05_01-21-02.png
```
and now reload it with fix
```
> loadrc
rc file loaded successfully.
> screenshot-area
Screenshotted to ~/Screenshots/screenshot-2024-02-05_01-21-41.png
```